### PR TITLE
change root file detection strategy

### DIFF
--- a/Listener/WebResourceListener.php
+++ b/Listener/WebResourceListener.php
@@ -234,8 +234,6 @@ class WebResourceListener
      */
     private function guessRootFile(UploadedFile $file)
     {
-        $rootFile = null;
-
         if (!$this->getZip()->open($file)) {
             throw new \Exception('Can not open archive file.');
         }
@@ -243,8 +241,7 @@ class WebResourceListener
         // Try to locate usual default HTML files to avoid unzip archive and scan directory tree
         foreach ($this->defaultIndexFiles as $html) {
             if (is_numeric($this->getZip()->locateName($html))) {
-                $rootFile = $html;
-                break;
+                return $html;
             }
         }
 
@@ -263,10 +260,10 @@ class WebResourceListener
 
         // Only one file
         if (count($htmlFiles) === 1) {
-            $rootFile = array_shift($htmlFiles);
+            return array_shift($htmlFiles);
         }
 
-        return $rootFile;
+        return null;
     }
 
     /**
@@ -276,26 +273,23 @@ class WebResourceListener
      */
     private function guessRootFileFromUnzipped($hash)
     {
-        $rootFile = null;
-
         // Grab all HTML files from Archive
         $htmlFiles = $this->getHTMLFiles($hash);
 
         // Only one file
         if (count($htmlFiles) === 1) {
-            $rootFile = array_shift($htmlFiles);
+            return array_shift($htmlFiles);
         }
 
         // Check usual default root files
         foreach ($this->defaultIndexFiles as $file) {
             if (in_array($file, $htmlFiles)) {
-                $rootFile = $file;
-                break;
+                return $file;
             }
         }
 
         // Unable to find an unique HTML file
-        return $rootFile;
+        return null;
     }
 
     /**


### PR DESCRIPTION
If no default html file is found in zip (web/index.html, index.html, etc.) there is now a fallback (we need it to be able to integrate HotPotatoes) :
- We scan directories of zip to find HTML files
- If a unique HTML file is found, zip is valid and this file is used as root of the WebResource

NOTE : There is an unmanaged use case : if there is no default HTML file and many HTML files in zip.

In this case, I think we have to return the list of all HTML files found to user and let him choose which is the root file.

I will try to handle this case if I have time and if this feature is usefull.
